### PR TITLE
fix(docs): Update signer package import in the consumer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/awslabs/aws-msk-iam-sasl-signer-go/signer"
+	"github.com/aws/aws-msk-iam-sasl-signer-go/signer"
 	"github.com/IBM/sarama"
 )
 


### PR DESCRIPTION
I noticed an outdated [reference](https://github.com/aws/aws-msk-iam-sasl-signer-go/blob/e0d344a836409aeed87a3f65f5ea0dbb3a30d0bc/README.md?plain=1#L123) while working through the examples in the README.

This PR changes the import path of the signer package in the consumer example from `"github.com/awslabs/aws-msk-iam-sasl-signer-go/signer"` to `"github.com/aws/aws-msk-iam-sasl-signer-go/signer"`.