### PR TITLE
Add GenerateAuthTokenFromRoleWithExternalId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
 
 ```go
 func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
-        token, _, err := signer.GenerateAuthTokenFromRole(context.TODO(), "<region>", "<my-role-arn>", "my-sts-session-name")
+        token, _, err := signer.GenerateAuthTokenFromRoleWithExternalId(context.TODO(), "<region>", "<my-role-arn>", "my-sts-session-name", "")
         return &sarama.AccessToken{Token: token}, err
 }
 ```

--- a/README.md
+++ b/README.md
@@ -237,13 +237,21 @@ func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
 ```
 
 * To use IAM credentials by assuming a IAM Role using sts, update the Token() function:
-
 ```go
 func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
-        token, _, err := signer.GenerateAuthTokenFromRoleWithExternalId(context.TODO(), "<region>", "<my-role-arn>", "my-sts-session-name", "")
+        token, _, err := signer.GenerateAuthTokenFromRole(context.TODO(), "<region>", "<my-role-arn>", "my-sts-session-name")
         return &sarama.AccessToken{Token: token}, err
 }
 ```
+
+* Optionally, if your IAM Role uses an External ID use the following (external-id can be left blank "" and it will be equivalent to the above):
+```go
+func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {
+        token, _, err := signer.GenerateAuthTokenFromRoleWithExternalId(context.TODO(), "<region>", "<my-role-arn>", "my-sts-session-name", "<external-id>")
+        return &sarama.AccessToken{Token: token}, err
+}
+```
+
 * To use IAM credentials from a credentials provider, update the Token() function:
 ```go
 func (t *MSKAccessTokenProvider) Token() (*sarama.AccessToken, error) {

--- a/signer/msk_auth_token_provider.go
+++ b/signer/msk_auth_token_provider.go
@@ -66,16 +66,7 @@ func GenerateAuthTokenFromProfile(ctx context.Context, region string, awsProfile
 func GenerateAuthTokenFromRole(
 	ctx context.Context, region string, roleArn string, stsSessionName string,
 ) (string, int64, error) {
-	if stsSessionName == "" {
-		stsSessionName = DefaultSessionName
-	}
-	credentials, err := loadCredentialsFromRoleArn(ctx, region, roleArn, stsSessionName, "")
-
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to load credentials: %w", err)
-	}
-
-	return constructAuthToken(ctx, region, credentials)
+	return GenerateAuthTokenFromRoleWithExternalId(ctx, region, roleArn, stsSessionName, "")
 }
 
 // GenerateAuthTokenFromRoleWithExternalId generates base64 encoded signed url as auth token by loading IAM credentials from an aws role Arn

--- a/signer/msk_auth_token_provider.go
+++ b/signer/msk_auth_token_provider.go
@@ -69,7 +69,25 @@ func GenerateAuthTokenFromRole(
 	if stsSessionName == "" {
 		stsSessionName = DefaultSessionName
 	}
-	credentials, err := loadCredentialsFromRoleArn(ctx, region, roleArn, stsSessionName)
+	credentials, err := loadCredentialsFromRoleArn(ctx, region, roleArn, stsSessionName, "")
+
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to load credentials: %w", err)
+	}
+
+	return constructAuthToken(ctx, region, credentials)
+}
+
+// GenerateAuthTokenFromRoleWithExternalId generates base64 encoded signed url as auth token by loading IAM credentials from an aws role Arn
+//
+// If the provided externalId is empty, it behaves exactly like GenerateAuthTokenFromRole.
+func GenerateAuthTokenFromRoleWithExternalId(
+	ctx context.Context, region string, roleArn string, stsSessionName string, externalId string,
+) (string, int64, error) {
+	if stsSessionName == "" {
+		stsSessionName = DefaultSessionName
+	}
+	credentials, err := loadCredentialsFromRoleArn(ctx, region, roleArn, stsSessionName, externalId)
 
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to load credentials: %w", err)
@@ -122,7 +140,7 @@ func loadCredentialsFromProfile(ctx context.Context, region string, awsProfile s
 // use your own credentials provider.
 // If you wish to use regional endpoint, please pass your own credentials provider.
 func loadCredentialsFromRoleArn(
-	ctx context.Context, region string, roleArn string, stsSessionName string,
+	ctx context.Context, region string, roleArn string, stsSessionName string, externalId string,
 ) (*aws.Credentials, error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 
@@ -135,6 +153,9 @@ func loadCredentialsFromRoleArn(
 	assumeRoleInput := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(roleArn),
 		RoleSessionName: aws.String(stsSessionName),
+	}
+	if externalId != "" {
+		assumeRoleInput.ExternalId = aws.String(externalId)
 	}
 	assumeRoleOutput, err := stsClient.AssumeRole(ctx, assumeRoleInput)
 	if err != nil {


### PR DESCRIPTION
Allows role assumption for roles with an external-id See: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_common-scenarios_third-party.html

Fixes: #24 
